### PR TITLE
Add build setting to enable specifying other tool locations

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,6 +9,7 @@ load(
     "extra_exec_rustc_flags",
     "extra_rustc_flag",
     "extra_rustc_flags",
+    "extra_rustc_toolchain_dirs",
     "is_proc_macro_dep",
     "is_proc_macro_dep_enabled",
     "no_std",
@@ -92,6 +93,15 @@ extra_exec_rustc_flag(
 
 per_crate_rustc_flag(
     name = "experimental_per_crate_rustc_flag",
+    build_setting_default = "",
+    visibility = ["//visibility:public"],
+)
+
+# This setting is to enable passing additional `-B` options to the CC toolchain driver binary to
+# aid in locating toolchain directories on systems where not all toolchain tools are installed in
+# the same system location.
+extra_rustc_toolchain_dirs(
+    name = "extra_rustc_toolchain_dirs",
     build_setting_default = "",
     visibility = ["//visibility:public"],
 )

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -48,6 +48,7 @@ load(
     _extra_exec_rustc_flags = "extra_exec_rustc_flags",
     _extra_rustc_flag = "extra_rustc_flag",
     _extra_rustc_flags = "extra_rustc_flags",
+    _extra_rustc_toolchain_dirs = "extra_rustc_toolchain_dirs",
     _is_proc_macro_dep = "is_proc_macro_dep",
     _is_proc_macro_dep_enabled = "is_proc_macro_dep_enabled",
     _no_std = "no_std",
@@ -116,6 +117,9 @@ extra_rustc_flag = _extra_rustc_flag
 # See @rules_rust//rust/private:rustc.bzl for a complete description.
 
 extra_rustc_flags = _extra_rustc_flags
+# See @rules_rust//rust/private:rustc.bzl for a complete description.
+
+extra_rustc_toolchain_dirs = _extra_rustc_toolchain_dirs
 # See @rules_rust//rust/private:rustc.bzl for a complete description.
 
 extra_exec_rustc_flag = _extra_exec_rustc_flag

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -719,6 +719,9 @@ _common_attrs = {
     "_extra_rustc_flags": attr.label(
         default = Label("//:extra_rustc_flags"),
     ),
+    "_extra_rustc_toolchain_dirs": attr.label(
+        default = Label("//:extra_rustc_toolchain_dirs"),
+    ),
     "_import_macro_dep": attr.label(
         default = Label("//util/import"),
         cfg = "exec",

--- a/rust/private/rustc.bzl
+++ b/rust/private/rustc.bzl
@@ -71,6 +71,11 @@ PerCrateRustcFlagsInfo = provider(
     fields = {"per_crate_rustc_flags": "List[string] Extra flags to pass to rustc in non-exec configuration"},
 )
 
+ExtraRustcToolchainDirsInfo = provider(
+    doc = "Pass each value as an additional `-B` flag to rustc invocations. Enables use of linkers placed in different directories on the system.",
+    fields = {"extra_rustc_toolchain_dirs": "List[string] Extra `-B` flags to pass to rustc."},
+)
+
 IsProcMacroDepInfo = provider(
     doc = "Records if this is a transitive dependency of a proc-macro.",
     fields = {"is_proc_macro_dep": "Boolean"},
@@ -447,6 +452,10 @@ def get_linker_and_args(ctx, attr, crate_type, cc_toolchain, feature_configurati
         action_name = action_name,
         variables = link_variables,
     )
+
+    # Make sure linker is locateable.
+    if hasattr(ctx.attr, "_extra_rustc_toolchain_dirs"):
+        link_args = link_args + ctx.attr._extra_rustc_toolchain_dirs[ExtraRustcToolchainDirsInfo].extra_rustc_toolchain_dirs
     link_env = cc_common.get_environment_variables(
         feature_configuration = feature_configuration,
         action_name = action_name,
@@ -2091,6 +2100,19 @@ per_crate_rustc_flag = rule(
         "Multiple uses are accumulated."
     ),
     implementation = _per_crate_rustc_flag_impl,
+    build_setting = config.string(flag = True, allow_multiple = True),
+)
+
+def _extra_rustc_toolchain_dirs_impl(ctx):
+    return ExtraRustcToolchainDirsInfo(extra_rustc_toolchain_dirs = ["-B" + f for f in ctx.build_setting_value if f != ""])
+
+extra_rustc_toolchain_dirs = rule(
+    doc = (
+        "Add additional `-B` rustc toolchain flags to specificy where CC toolchain executables are located on the system by" +
+        "using the command line switch `--@rules_rust//:extra_rustc_toolchain_dirs`. " +
+        "Multiple uses are accumulated."
+    ),
+    implementation = _extra_rustc_toolchain_dirs_impl,
     build_setting = config.string(flag = True, allow_multiple = True),
 )
 


### PR DESCRIPTION
On some systems, the CC toolchain discovered by bazel uses a different path for the linker than where the linker (that is specified by the `-fuse-ld=` flag) actually lives on the system.

The issue stems from rules_rust deciding to pass `-fuse-ld=lld` a link arg, rather than just using what was detected by the CC toolchain. This results in the linker not being found, as reported by
https://github.com/lowRISC/opentitan/issues/12448

This is a workaround that enables telling rules_rust where other linker directories might be on your system. It is used by passing `--@rules_rust//:extra_rustc_toolchain_dirs=/path/to/somewhere/else` to `bazel ...` invocations.